### PR TITLE
Upgrade ruby-next

### DIFF
--- a/.rbnextrc
+++ b/.rbnextrc
@@ -1,0 +1,2 @@
+nextify: |
+  --transpile-mode=rewrite

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 desc "Run Ruby Next nextify"
 task :nextify do
-  sh "bundle exec ruby-next nextify ./lib --transpile-mode=rewrite -V"
+  sh "bundle exec ruby-next nextify ./lib -V"
 end
 
 desc "Run specs without Rails"

--- a/gemfiles/rubocop.gemfile
+++ b/gemfiles/rubocop.gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org" do
   gem "rubocop-md", "~> 0.3"
   gem "standard", "0.2.0"
-  gem "ruby-next", ">= 0.6.0"
+  gem "ruby-next", ">= 0.7.0"
 end

--- a/graphql-ruby-fragment_cache.gemspec
+++ b/graphql-ruby-fragment_cache.gemspec
@@ -24,7 +24,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "graphql", ">= 1.10.8"
 
-  spec.add_runtime_dependency "ruby-next-core", ">= 0.5.1"
+  # When gem is installed from source, we add `ruby-next` as a dependency
+  # to auto-transpile source files during the first load
+  if File.directory?(File.join(__dir__, ".git"))
+    spec.add_runtime_dependency "ruby-next", ">= 0.7.0"
+  else
+    spec.add_runtime_dependency "ruby-next-core", ">= 0.7.0"
+  end
 
   spec.add_development_dependency "combustion", "~> 1.1"
   spec.add_development_dependency "activerecord"

--- a/lib/graphql-fragment_cache.rb
+++ b/lib/graphql-fragment_cache.rb
@@ -1,6 +1,6 @@
 require "ruby-next"
 
 require "ruby-next/language/setup"
-RubyNext::Language.setup_gem_load_path
+RubyNext::Language.setup_gem_load_path(transpile: true)
 
 require "graphql/fragment_cache"


### PR DESCRIPTION
The main goal of this PR is to make it possible to install a gem from source even in older Rubies.

That could be achieved by using a new [auto-transpiling](https://github.com/ruby-next/ruby-next#transpiled-files-vs-vsc-vs-installing-from-source) Ruby Next feature.

Also, we can make Ruby Next installed automatically by making it a runtime dependency in case the gem is loaded from source (we check for the presence of the `.git` folder for that).