### PR TITLE
Add Rails cache key calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## [Unreleased]
+
+- [PR#37](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/37) Try to use `cache_key_with_version` or `cache_key` with Rails CacheKeyBuilder
+
 ## 1.0.5 (2020-10-13)
 
 - [PR#35](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/35) Prefer using `#write_multi` on cache store when possible ([@DmitryTsepelev][])

--- a/lib/graphql/fragment_cache/rails/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/rails/cache_key_builder.rb
@@ -6,6 +6,8 @@ module GraphQL
     class CacheKeyBuilder
       def object_key(obj)
         return obj.graphql_cache_key if obj.respond_to?(:graphql_cache_key)
+        return obj.cache_key_with_version if obj.respond_to?(:cache_key_with_version)
+        return obj.cache_key if obj.respond_to?(:cache_key)
         return obj.map { |item| object_key(item) }.join("/") if obj.is_a?(Array)
         return object_key(obj.to_a) if obj.respond_to?(:to_a)
 

--- a/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
@@ -39,6 +39,30 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
   it "uses Cache.expand_cache_key" do
     allow(ActiveSupport::Cache).to receive(:expand_cache_key).with(object) { "as:cache:key" }
 
-    is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/as:cache:key"
+    is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/Post#42"
+  end
+
+  context "when object is passed and responds to #graphql_cache_key" do
+    before do
+      object.singleton_class.define_method(:graphql_cache_key) { "{graphql_cache_key}" }
+    end
+
+    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{graphql_cache_key}" }
+  end
+
+  context "when object is passed and responds to #cache_key_with_version" do
+    before do
+      object.singleton_class.define_method(:cache_key_with_version) { "{cache_key_with_version}" }
+    end
+
+    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache_key_with_version}" }
+  end
+
+  context "when object is passed and responds to #cache_key" do
+    before do
+      object.singleton_class.define_method(:cache_key) { "{cache-key}" }
+    end
+
+    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache-key}" }
   end
 end


### PR DESCRIPTION
I think this fixes #36. It seems to work for us, it hasn't been extensively tested yet. 

I think the README might be out of date as well for the order of operations, under the section "The way cache key part is generated for the passed argument"