### PR TITLE
Add object_cache_key to CacheKeyBuilder

### DIFF
--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -113,8 +113,13 @@ module GraphQL
 
       def build
         Digest::SHA1.hexdigest("#{schema_cache_key}/#{query_cache_key}").then do |base_key|
-          next base_key unless object
-          "#{base_key}/#{object_key(object)}"
+          if @options[:object_cache_key]
+            "#{base_key}/#{@options[:object_cache_key]}"
+          elsif object
+            "#{base_key}/#{object_key(object)}"
+          else
+            base_key
+          end
         end
       end
 

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -29,8 +29,9 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
   let(:object) { nil }
   let(:context) { {} }
   let(:query_obj) { GraphQL::Query.new(schema, query, variables: variables, context: context) }
+  let(:options) { {} }
 
-  subject { described_class.call(object: object, query: query_obj, path: path) }
+  subject { described_class.call(object: object, query: query_obj, path: path, **options) }
 
   # Make cache keys raw for easier debugging
   let(:schema_cache_key) { "schema_key" }
@@ -196,6 +197,15 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     it "fallbacks to #to_s" do
       is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{post.author}"
+    end
+  end
+
+  context "when object_cache_key is passed" do
+    let(:options) { { object_cache_key: "test_cache_key/1-230834092834098" } }
+    let(:object) { post.author }
+
+    it "uses the option instead of the object's cache_key" do
+      is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{options[:object_cache_key]}"
     end
   end
 

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -201,7 +201,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
   end
 
   context "when object_cache_key is passed" do
-    let(:options) { { object_cache_key: "test_cache_key/1-230834092834098" } }
+    let(:options) { {object_cache_key: "test_cache_key/1-230834092834098"} }
     let(:object) { post.author }
 
     it "uses the option instead of the object's cache_key" do


### PR DESCRIPTION
As discussed in #49, this allows specifying the object's cache key.