### PR TITLE
Use thread-safe query result for final_value

### DIFF
--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -53,7 +53,7 @@ module GraphQL
       end
 
       def final_value
-        @final_value ||= context.query.result['data']
+        @final_value ||= context.query.result["data"]
       end
     end
   end

--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -53,7 +53,7 @@ module GraphQL
       end
 
       def final_value
-        @final_value ||= interpreter_context[:runtime].final_value
+        @final_value ||= context.query.result['data']
       end
     end
   end


### PR DESCRIPTION
Hi again! 👋 In asynchronous situations, it is possible for `context`'s runtime `final_value` to return `nil`, even when there was previously a value present. This resulted in an error in `Fragment#value` or a quietly dead thread. 

I asked rmosolgo if there was a safer way to retrieve the final result value in `after_query` and his suggestion was to pull the data from the query result. We've been running with this code for a couple of days and it appears to have resolved the issue. 

~We could also check for both...~ Nevermind, the old code that this replaces can result in receiving unresolved promises or other async values awaiting `sync`. 