### PR TITLE
Include arguments in selections_cache_key

### DIFF
--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -176,6 +176,25 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     end
   end
 
+  context "when nested field specifies constant arguments" do
+    let(:query) do
+      <<~GQL
+        query GetPost($id: ID!) {
+          cachedPost(id: $id) {
+            id
+            title
+            author(cached: false, version: 5) {
+              id
+              name
+            }
+          }
+        }
+      GQL
+    end
+
+    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author(cached:false,version:5)[id.name]]" }
+  end
+
   context "when object is passed and responds to #cache_key" do
     let(:object) { post }
 

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -25,7 +25,11 @@ module Types
     field :id, ID, null: false
     field :title, String, null: false
     field :cached_title, String, null: false, cache_fragment: true, method: :title
-    field :author, User, null: false
+    field :author, User, null: false do
+      argument :version, Integer, required: false
+      argument :cached, Boolean, required: false
+    end
+
     field :cached_author, User, null: false
     field :batched_cached_author, User, null: false
 
@@ -94,9 +98,12 @@ module Types
 end
 
 class TestSchema < GraphQL::Schema
-  use GraphQL::Execution::Interpreter
-  use GraphQL::Analysis::AST
-  use GraphQL::Pagination::Connections
+  if Gem::Dependency.new("graphql", "< 1.12.0").match?("graphql", GraphQL::VERSION)
+    use GraphQL::Execution::Interpreter
+    use GraphQL::Analysis::AST
+    use GraphQL::Pagination::Connections
+  end
+
   use GraphQL::FragmentCache
 
   query Types::Query


### PR DESCRIPTION
~(This is a draft because of a probable refactor, [see my comment in the files](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/54/files))~

We have some nested cache fragments, and we had an issue where the parent keys of the children are not including children's nested hard-coded arguments. This results in queries with the same AST but different internal arguments using the same cache key, which is not correct. For example:

```graphql
query something($id: ID!) {
  thing(id: $id) {
    internalThing(parameter: "words")
  }
}
```

and 

```graphql
query something($id: ID!) {
  thing(id: $id) {
    internalThing(anotherParameter: "TEST")
  }
}
```

will have the same cache key.