### PR TITLE
Add a way to force a cache miss

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,17 @@ class QueryType < BaseObject
 end
 ```
 
+## Forcing the cache
+
+You can force a cache miss by adding `force_cache: true` to the query context:
+
+```ruby
+MyAppSchema.execute('query { posts { title } }', context: {force_cache: true})
+```
+
+This will treat the cache value as missing even if it's present, which can be
+useful for cache warmers.
+
 ## Cache storage and options
 
 It's up to your to decide which caching engine to use, all you need is to configure the cache store:

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ end
 You can force a cache miss by adding `force_cache: true` to the query context:
 
 ```ruby
-MyAppSchema.execute('query { posts { title } }', context: {force_cache: true})
+MyAppSchema.execute("query { posts { title } }", context: {force_cache: true})
 ```
 
 This will treat the cache value as missing even if it's present, which can be

--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ You can force the cache to renew during query execution by adding
 MyAppSchema.execute("query { posts { title } }", context: {renew_cache: true})
 ```
 
-This will treat the cache value as missing even if it's present, and store a
-fresh new computed value in the cache. This can be useful for cache warmers.
+This will treat any cached value as missing even if it's present, and store
+fresh new computed values in the cache. This can be useful for cache warmers.
 
 ## Cache storage and options
 

--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -19,6 +19,7 @@ module GraphQL
       NIL_IN_CACHE = Object.new
 
       def read(keep_in_context = false)
+        return nil if context[:force_cache] == true
         return read_from_context { value_from_cache } if keep_in_context
 
         value_from_cache

--- a/spec/graphql/fragment_cache/field_extensions_spec.rb
+++ b/spec/graphql/fragment_cache/field_extensions_spec.rb
@@ -271,4 +271,24 @@ describe "cache_fragment: option" do
       expect(::Post).to have_received(:find).once
     end
   end
+
+  context "when :force_cache is in the context" do
+    let(:context) { {force_cache: true} }
+
+    it "forces a cache miss and stores the computed value in the cache" do
+      expect(execute_query.dig("data", "post")).to eq({
+        "id" => "1",
+        "title" => "new option test"
+      })
+
+      # make object dirty
+      post.title = "new option test 2"
+
+      context[:force_cache] = false
+      expect(execute_query.dig("data", "post")).to eq({
+        "id" => "1",
+        "title" => "new option test"
+      })
+    end
+  end
 end


### PR DESCRIPTION
Useful for cache warmers if you want to renew the cache.

Similar to `rails`' `ActiveSupport::Cache::Store#fetch`'s [`force: true`](https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch) option and `graphql-cache`'s [`force_cache`](https://github.com/stackshareio/graphql-cache/#forcing-the-cache) option.