### PR TITLE
Add a configure block notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ end
 It's up to your to decide which caching engine to use, all you need is to configure the cache store:
 
 ```ruby
-GraphQL::FragmentCache.cache_store = MyCacheStore.new
+GraphQL::FragmentCache.configure do |config|
+  config.cache_store = MyCacheStore.new
+end
 ```
 
 Or, in Rails:

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -32,6 +32,10 @@ module GraphQL
         GraphQL::Pagination::Connections.prepend(Connections::Patch)
       end
 
+      def configure
+        yield self
+      end
+
       def cache_store=(store)
         unless store.respond_to?(:read)
           raise ArgumentError, "Store must implement #read(key) method"

--- a/spec/graphql/fragment_cache_spec.rb
+++ b/spec/graphql/fragment_cache_spec.rb
@@ -86,4 +86,16 @@ describe GraphQL::FragmentCache do
       expect { described_class.cache_store = obj }.not_to raise_error
     end
   end
+
+  describe ".configure" do
+    it "accepts options with a block notation" do
+      obj = GraphQL::FragmentCache::MemoryStore.new
+
+      described_class.configure do |config|
+        config.cache_store = obj
+      end
+
+      expect(described_class.cache_store).to eq obj
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the following alternative way to configure the gem (typically in a Rails initializer):

```ruby
GraphQL::FragmentCache.configure do |config|
  config.cache_store = MyCacheStore.new
end
```

The main benefit is that it is less verbose once you start having multiple configuration options (like https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/64):

```ruby
GraphQL::FragmentCache.configure do |config|
  config.cache_store = MyCacheStore.new
  config.option2 = "foo"
  config.option3 = "bar"
end
```

I also like this notation because its is used by many gems, so it feels familiar.