### PR TITLE
Add a cache namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Cache keys consist of the following parts: namespace, implicit key, and explicit
 You can optionally define a namespace that will be prefixed to every cache key:
 
 ```ruby
-GraphQL::FragmentCache.namespace = 'my-prefix'
+GraphQL::FragmentCache.namespace = "my-prefix"
 ```
 
 ### Implicit cache key

--- a/README.md
+++ b/README.md
@@ -80,11 +80,19 @@ end
 
 ## Cache key generation
 
-Cache keys consist of implicit and explicit (provided by user) parts.
+Cache keys consist of the following parts: namespace, implicit key, and explicit key.
+
+### Cache namespace
+
+You can optionally define a namespace that will be prefixed to every cache key:
+
+```ruby
+GraphQL::FragmentCache.namespace = 'my-prefix'
+```
 
 ### Implicit cache key
 
-Implicit part of a cache key (its prefix) contains the information about the schema and the current query. It includes:
+Implicit part of a cache key contains the information about the schema and the current query. It includes:
 
 - Hex gsdigest of the schema definition (to make sure cache is cleared when the schema changes).
 - The current query fingerprint consisting of a _path_ to the field, arguments information and the selections set.

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -21,6 +21,7 @@ module GraphQL
   module FragmentCache
     class << self
       attr_reader :cache_store
+      attr_accessor :namespace
 
       def use(schema_defn, options = {})
         verify_interpreter_and_analysis!(schema_defn)

--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -185,7 +185,11 @@ module GraphQL
       end
 
       def object_cache_key
-        @options[:object_cache_key] || object&._graphql_cache_key
+        @options[:object_cache_key] || object_key(object)
+      end
+
+      def object_key(obj)
+        obj&._graphql_cache_key
       end
     end
   end

--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -126,18 +126,18 @@ module GraphQL
       end
 
       def build
-        Digest::SHA1.hexdigest("#{schema_cache_key}/#{query_cache_key}").then do |base_key|
-          if @options[:object_cache_key]
-            "#{base_key}/#{@options[:object_cache_key]}"
-          elsif object
-            "#{base_key}/#{object_key(object)}"
-          else
-            base_key
-          end
-        end
+        [
+          GraphQL::FragmentCache.namespace,
+          implicit_cache_key,
+          object_cache_key
+        ].compact.join("/")
       end
 
       private
+
+      def implicit_cache_key
+        Digest::SHA1.hexdigest("#{schema_cache_key}/#{query_cache_key}")
+      end
 
       def schema_cache_key
         @options.fetch(:schema_cache_key) { schema.schema_cache_key }
@@ -184,8 +184,8 @@ module GraphQL
         "{#{argument.map { "#{_1}:#{traverse_argument(_2)}" }.sort.join(",")}}"
       end
 
-      def object_key(obj)
-        obj._graphql_cache_key
+      def object_cache_key
+        @options[:object_cache_key] || object&._graphql_cache_key
       end
     end
   end

--- a/lib/graphql/fragment_cache/rails/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/rails/cache_key_builder.rb
@@ -5,6 +5,7 @@ module GraphQL
     # Extends key builder to use .expand_cache_key in Rails
     class CacheKeyBuilder
       def object_key(obj)
+        return nil if obj.nil?
         return obj.graphql_cache_key if obj.respond_to?(:graphql_cache_key)
         return obj.cache_key_with_version if obj.respond_to?(:cache_key_with_version)
         return obj.cache_key if obj.respond_to?(:cache_key)

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -42,6 +42,13 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
   specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]" }
 
+  context "when a namespace is configured" do
+    before { GraphQL::FragmentCache.namespace = "my-prefix" }
+    after { GraphQL::FragmentCache.namespace = nil }
+
+    specify { is_expected.to eq "my-prefix/schema_key/cachedPost(id:#{id})[id.title]" }
+  end
+
   context "when cached field has nested selections" do
     let(:query) do
       <<~GQL


### PR DESCRIPTION
This PR allows you to configure a namespace which will be prefixed to all cache keys:

```ruby
GraphQL::FragmentCache.namespace = 'graphql'
```

This can be useful if the cache store is shared, allows listing keys, and you want to to differentiate between the graphql-fragment_cache ones and the rest. For example in Redis:

```ruby
pry(main)> $redis.keys

=> [
    "graphql/7ace5027bfa9cd0314b3e310d3ae10921a065ef9",
    "some-other-unrelated-key"
]
```

Or if for some reason you want to clear all graphql fragment cache keys: 

```ruby
Rails.cache.delete_matched('graphql/*') # works if your cache store is Redis
```

Currently this PR does not set a default namespace, but I think there should be one like `"graphql"` maybe. Let me know what you think (it is very easy to add) otherwise this PR can be shipped as is.