### PR TITLE
Add default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,20 @@ field :post, PostType, cache_fragment: {if: -> { current_user.nil? }} do
 end
 ```
 
+## Default options
+
+You can configure default options that will be passed to all `cache_fragment`
+calls and `cache_fragment:` configurations. For example:
+
+```ruby
+GraphQL::FragmentCache.configure do |config|
+  config.default_options = {
+    expires_in: 1.hour, # Expire cache keys after 1 hour
+    schema_cache_key: nil # Do not clear the cache on each schema change
+  }
+end
+```
+
 ## Renewing the cache
 
 You can force the cache to renew during query execution by adding

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -22,6 +22,7 @@ module GraphQL
     class << self
       attr_reader :cache_store
       attr_accessor :namespace
+      attr_accessor :default_options
 
       def use(schema_defn, options = {})
         verify_interpreter_and_analysis!(schema_defn)
@@ -81,6 +82,7 @@ module GraphQL
     end
 
     self.cache_store = MemoryStore.new
+    self.default_options = {}
   end
 end
 

--- a/lib/graphql/fragment_cache/field_extension.rb
+++ b/lib/graphql/fragment_cache/field_extension.rb
@@ -28,7 +28,8 @@ module GraphQL
       end
 
       def initialize(options:, **_rest)
-        @cache_options = options || {}
+        @cache_options = GraphQL::FragmentCache.default_options.merge(options || {})
+        @cache_options[:default_options_merged] = true
 
         @context_key = @cache_options.delete(:context_key)
         @cache_key = @cache_options.delete(:cache_key)

--- a/lib/graphql/fragment_cache/object_helpers.rb
+++ b/lib/graphql/fragment_cache/object_helpers.rb
@@ -25,7 +25,9 @@ module GraphQL
       def cache_fragment(object_to_cache = NO_OBJECT, **options, &block)
         raise ArgumentError, "Block or argument must be provided" unless block_given? || object_to_cache != NO_OBJECT
 
-        options = GraphQL::FragmentCache.default_options.merge(options)
+        unless options.delete(:default_options_merged)
+          options = GraphQL::FragmentCache.default_options.merge(options)
+        end
 
         if options.key?(:if) || options.key?(:unless)
           disabled = options.key?(:if) ? !options.delete(:if) : options.delete(:unless)

--- a/lib/graphql/fragment_cache/object_helpers.rb
+++ b/lib/graphql/fragment_cache/object_helpers.rb
@@ -25,6 +25,8 @@ module GraphQL
       def cache_fragment(object_to_cache = NO_OBJECT, **options, &block)
         raise ArgumentError, "Block or argument must be provided" unless block_given? || object_to_cache != NO_OBJECT
 
+        options = GraphQL::FragmentCache.default_options.merge(options)
+
         if options.key?(:if) || options.key?(:unless)
           disabled = options.key?(:if) ? !options.delete(:if) : options.delete(:unless)
           if disabled


### PR DESCRIPTION
I find myself needing to set the same options to all my `cache_fragment:` or `#cache_fragment`. This PR allows you to configure default options globally instead:

```ruby
config.default_options = {
  expires_in: 1.hour,
  schema_cache_key: nil,
  cache_key: :object
}
```

These options can be overriden, for example by doing `cache_fragment(expires_in: 5.minutes)`.

By the way, setting `schema_cache_key: nil` as a default option is a low-level way to fix #9.