### PR TITLE
Add selection alias to cache keys

### DIFF
--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -22,6 +22,8 @@ module GraphQL
             children = val.selections.empty? ? "" : "[#{val.selections.to_selections_key}]"
 
             field_name = val.field.name
+            field_alias = val.ast_nodes.map(&:alias).join
+            field_name = "#{field_alias}:#{field_name}" unless field_alias.empty?
 
             unless val.arguments.empty?
               args = val.arguments.map { "#{_1}:#{traverse_argument(_2)}" }.sort.join(",")

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -68,6 +68,25 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
   end
 
+  context "when cached field has aliased selections" do
+    let(:query) do
+      <<~GQL
+        query GetPost($id: ID!) {
+          cachedPost(id: $id) {
+            postId: id
+            title
+            author {
+              authorId: id
+              name
+            }
+          }
+        }
+      GQL
+    end
+
+    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[postId:id.title.author[authorId:id.name]]" }
+  end
+
   context "when argument is input" do
     let(:query) do
       <<~GQL

--- a/spec/graphql/fragment_cache/object_helpers_spec.rb
+++ b/spec/graphql/fragment_cache/object_helpers_spec.rb
@@ -345,6 +345,44 @@ describe "#cache_fragment" do
       end
     end
 
+    context "when selection aliases are used" do
+      let(:query) do
+        <<~GQL
+          query getPost($id: ID!) {
+            post(id: $id) {
+              id
+            }
+          }
+        GQL
+      end
+
+      let(:query_with_aliased_selection) do
+        <<~GQL
+          query getPost($id: ID!) {
+            post(id: $id) {
+              postId: id
+            }
+          }
+        GQL
+      end
+
+      let(:resolver) do
+        ->(id:) do
+          cache_fragment(Post.find(id))
+        end
+      end
+
+      it "returns cached fragment for different selection aliases independently" do
+        expect(execute_query.dig("data", "post")).to eq({
+          "id" => "1"
+        })
+
+        expect(execute_query(query_with_aliased_selection).dig("data", "post")).to eq({
+          "postId" => "1"
+        })
+      end
+    end
+
     context "when resolver is used" do
       let(:resolver_class) do
         Class.new(GraphQL::Schema::Resolver) do


### PR DESCRIPTION
Unique cache keys are already generated if a field containing selections is aliased. This PR also adds uniqueness for aliases on individual selections. I couldn't find a way to get to the aliases other than going through the ast_nodes, open to alternatives if you're aware of them!