### PR TITLE
Fix Renew Cache Read Multi Bug

### DIFF
--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -12,7 +12,9 @@ module GraphQL
 
       class << self
         def read_multi(fragments)
-          return fragments.map { |f| [f, f.read] }.to_h unless FragmentCache.cache_store.respond_to?(:read_multi)
+          unless FragmentCache.cache_store.respond_to?(:read_multi)
+            return fragments.map { |f| [f, f.read] }.to_h
+          end
 
           fragments_to_cache_keys = fragments.map { |f| [f, f.cache_key] }.to_h
 

--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -16,10 +16,12 @@ module GraphQL
             return fragments.map { |f| [f, f.read] }.to_h
           end
 
-          fragments_to_cache_keys = fragments.map { |f| [f, f.cache_key] }.to_h
+          fragments_to_cache_keys = fragments
+            .map { |f| [f, f.cache_key] }.to_h
 
           # Filter out all the cache_keys for fragments with renew_cache: true in their context
-          cache_keys = fragments_to_cache_keys.reject { |k, _v| k.context[:renew_cache] == true }.values
+          cache_keys = fragments_to_cache_keys
+            .reject { |k, _v| k.context[:renew_cache] == true }.values
 
           # If there are cache_keys look up values with read_multi otherwise return an empty hash
           cache_keys_to_values = if cache_keys.empty?
@@ -29,7 +31,8 @@ module GraphQL
           end
 
           # Fragmenst without values or with renew_cache: true in their context will have nil values like the read method
-          fragments_to_cache_keys.map { |fragment, cache_key| [fragment, cache_keys_to_values[cache_key]] }.to_h
+          fragments_to_cache_keys
+            .map { |fragment, cache_key| [fragment, cache_keys_to_values[cache_key]] }.to_h
         end
       end
 

--- a/lib/graphql/fragment_cache/fragment.rb
+++ b/lib/graphql/fragment_cache/fragment.rb
@@ -17,14 +17,14 @@ module GraphQL
           fragments_to_cache_keys = fragments.map { |f| [f, f.cache_key] }.to_h
 
           # Filter out all the cache_keys for fragments with renew_cache: true in their context
-          cache_keys = fragments_to_cache_keys.reject { |k, _v| k.context[:renew_cache] == true}.values
+          cache_keys = fragments_to_cache_keys.reject { |k, _v| k.context[:renew_cache] == true }.values
 
           # If there are cache_keys look up values with read_multi otherwise return an empty hash
-          cache_keys_to_values = unless cache_keys.empty?
-                                   FragmentCache.cache_store.read_multi(*cache_keys)
-                                 else
-                                   {}
-                                 end
+          cache_keys_to_values = if cache_keys.empty?
+            {}
+          else
+            FragmentCache.cache_store.read_multi(*cache_keys)
+          end
 
           # Fragmenst without values or with renew_cache: true in their context will have nil values like the read method
           fragments_to_cache_keys.map { |fragment, cache_key| [fragment, cache_keys_to_values[cache_key]] }.to_h

--- a/spec/graphql/fragment_cache/fragment_spec.rb
+++ b/spec/graphql/fragment_cache/fragment_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe GraphQL::FragmentCache::Fragment do
+  describe "#read_multi" do
+    context "when all fragments don't have renew_cache in their context" do
+      it 'calls read_multi and returns the cached values for all of them' do
+        fragment_doubles = fragment_doubles_factory(count: 3)
+        cache_store_double = double("cache_store", read_multi: fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+
+        allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
+
+        expect(described_class.read_multi(fragment_doubles).values).to eq fragment_doubles.map(&:read)
+        expect(cache_store_double).to have_received(:read_multi).with(*fragment_doubles.map(&:cache_key))
+      end
+    end
+
+    context "when all fragments have renew_cache: true in their context" do
+      it 'it does not call read_multi and returns a nil value for all of them' do
+        fragment_doubles = fragment_doubles_factory(count: 3, ctx: {renew_cache: true})
+        cache_store_double = double("cache_store", read_multi: fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+
+        allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
+
+        expect(described_class.read_multi(fragment_doubles).values).to eq fragment_doubles.map{nil}
+        expect(cache_store_double).not_to have_received(:read_multi)
+      end
+    end
+
+    context "when some fragments have renew_cache: true in their context and other don't" do
+      it 'it does not call read_multi for the ones with renew_cache: true and returns a nil value for them' do
+        renew_fragment_doubles = fragment_doubles_factory(count: 3, ctx: {renew_cache: true})
+        # use sample to randomly select from contexts that should not renew the cache
+        invalid_context = {renew_cache: [false, 'false', 1, 3.14159].sample}
+        cache_fragment_doubles = fragment_doubles_factory(count: 3, ctx: invalid_context)
+        fragment_doubles = cache_fragment_doubles + renew_fragment_doubles
+        cache_store_double = double("cache_store", read_multi: cache_fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+
+        allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
+
+        expect(described_class.read_multi(fragment_doubles).values).to eq cache_fragment_doubles.map(&:read) + renew_fragment_doubles.map{nil}
+        expect(cache_store_double).to have_received(:read_multi).with(*cache_fragment_doubles.map(&:cache_key))
+      end
+    end
+
+    # creates an array of fragment doubles with random cache_keys and read values
+    def fragment_doubles_factory(count:, ctx: {})
+        (1..count).map do |i|
+          r = srand
+          instance_double(GraphQL::FragmentCache::Fragment, context: ctx, read: r, cache_key: r.to_s)
+        end
+    end
+  end
+end

--- a/spec/graphql/fragment_cache/fragment_spec.rb
+++ b/spec/graphql/fragment_cache/fragment_spec.rb
@@ -5,9 +5,9 @@ require "spec_helper"
 describe GraphQL::FragmentCache::Fragment do
   describe "#read_multi" do
     context "when all fragments don't have renew_cache in their context" do
-      it 'calls read_multi and returns the cached values for all of them' do
+      it "calls read_multi and returns the cached values for all of them" do
         fragment_doubles = fragment_doubles_factory(count: 3)
-        cache_store_double = double("cache_store", read_multi: fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+        cache_store_double = double("cache_store", read_multi: fragment_doubles.map { |f| [f.cache_key, f.read] }.to_h)
 
         allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
 
@@ -17,39 +17,39 @@ describe GraphQL::FragmentCache::Fragment do
     end
 
     context "when all fragments have renew_cache: true in their context" do
-      it 'it does not call read_multi and returns a nil value for all of them' do
+      it "it does not call read_multi and returns a nil value for all of them" do
         fragment_doubles = fragment_doubles_factory(count: 3, ctx: {renew_cache: true})
-        cache_store_double = double("cache_store", read_multi: fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+        cache_store_double = double("cache_store", read_multi: fragment_doubles.map { |f| [f.cache_key, f.read] }.to_h)
 
         allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
 
-        expect(described_class.read_multi(fragment_doubles).values).to eq fragment_doubles.map{nil}
+        expect(described_class.read_multi(fragment_doubles).values).to eq fragment_doubles.map { nil }
         expect(cache_store_double).not_to have_received(:read_multi)
       end
     end
 
     context "when some fragments have renew_cache: true in their context and other don't" do
-      it 'it does not call read_multi for the ones with renew_cache: true and returns a nil value for them' do
+      it "it does not call read_multi for the ones with renew_cache: true and returns a nil value for them" do
         renew_fragment_doubles = fragment_doubles_factory(count: 3, ctx: {renew_cache: true})
         # use sample to randomly select from contexts that should not renew the cache
-        invalid_context = {renew_cache: [false, 'false', 1, 3.14159].sample}
+        invalid_context = {renew_cache: [false, "false", 1, 3.14159].sample}
         cache_fragment_doubles = fragment_doubles_factory(count: 3, ctx: invalid_context)
         fragment_doubles = cache_fragment_doubles + renew_fragment_doubles
-        cache_store_double = double("cache_store", read_multi: cache_fragment_doubles.map{ |f| [f.cache_key, f.read]}.to_h)
+        cache_store_double = double("cache_store", read_multi: cache_fragment_doubles.map { |f| [f.cache_key, f.read] }.to_h)
 
         allow(GraphQL::FragmentCache).to receive(:cache_store).and_return(cache_store_double)
 
-        expect(described_class.read_multi(fragment_doubles).values).to eq cache_fragment_doubles.map(&:read) + renew_fragment_doubles.map{nil}
+        expect(described_class.read_multi(fragment_doubles).values).to eq cache_fragment_doubles.map(&:read) + renew_fragment_doubles.map { nil }
         expect(cache_store_double).to have_received(:read_multi).with(*cache_fragment_doubles.map(&:cache_key))
       end
     end
 
     # creates an array of fragment doubles with random cache_keys and read values
     def fragment_doubles_factory(count:, ctx: {})
-        (1..count).map do |i|
-          r = srand
-          instance_double(GraphQL::FragmentCache::Fragment, context: ctx, read: r, cache_key: r.to_s)
-        end
+      (1..count).map do |i|
+        r = srand
+        instance_double(GraphQL::FragmentCache::Fragment, context: ctx, read: r, cache_key: r.to_s)
+      end
     end
   end
 end


### PR DESCRIPTION
## Bug:
When the context `{renew_cache: true}` is passed to a cached query in an application that is using a `cache_store` that supports `read_multi` (e.g. Redis) the cache is not cleared and `{renew_cache: true}` is ignored.

### Expected Behavior:
When the context `{renew_cache: true}` is passed to a cached query the cache is renewed.

## Description:
This commit fixes the above issue by adding logic that checks for `{renew_cache: true}` in the context of fragments passed to the `read_multi` method and returns `nil` for their value so that cache is refreshed. With this change, there is feature parity between cache stores that support `read_multi` and those that don't.