### PR TITLE
Fix conditional caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+- [PR#85](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/85) Support passing Symbols to `if:` and `unless:` ([@palkan][])
+
+- [PR#85](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/85) Fix conditional caching ([@palkan][])
+
 ## 1.13.1 (2022-10-12)
 
 - [PR#84](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/84) Fix Renew Cache Read Multi Bug ([@KTSCode][])

--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ end
 field :post, PostType, cache_fragment: {if: -> { current_user.nil? }} do
   argument :id, ID, required: true
 end
+
+# or
+
+field :post, PostType, cache_fragment: {if: :current_user?} do
+  argument :id, ID, required: true
+end
 ```
 
 ## Default options

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -10,6 +10,14 @@ end
 module Types
   class Base < GraphQL::Schema::Object
     include GraphQL::FragmentCache::Object
+
+    def current_user?
+      context[:current_user]
+    end
+
+    def no_current_user?
+      context[:current_user].nil?
+    end
   end
 
   class User < Base


### PR DESCRIPTION
We persisted the result of the first execution of the passed Proc and used it for all subsequent calls — 😬

Also added support for passing Symbols to `if` and `unless`:

```ruby
field :collection, resolver:  SomeResolver, cache_fragment: {if: :anonymous_user?}
```