### PR TITLE
Make `cache_key` option support procs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- [PR#86](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/86) Support passing Procs and any Symbol to `cache_key:` ([@jeromedalbert][])
+- [PR#86](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/86) Support passing Procs to `cache_key:` ([@jeromedalbert][])
 - [PR#89](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/89) Use a "graphql" cache namespace by default ([@jeromedalbert][])
 
 ## 1.15.0 (2022-10-27)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#86](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/86) Support passing Procs and any Symbol to `cache_key:` ([@jeromedalbert][])
+
 ## 1.15.0 (2022-10-27)
 
 - [PR#43](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/43) Implement `skip_cache_when_query_has_errors` option to skip caching when query was resolved with errors ([@DmitryTsepelev][])

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ def post(id:)
 end
 ```
 
-Also, you can pass `:value` to the `cache_key:` argument to use the returned value to build a key:
+You can pass the special `:value` symbol to the `cache_key:` argument to use the returned value to build a key:
 
 ```ruby
 field :post, PostType, null: true, cache_fragment: {cache_key: :value} do
@@ -235,6 +235,28 @@ def post(id:)
   post = Post.find(id)
   cache_fragment(post) { post }
 end
+```
+
+Passing any other symbol to `cache_key:` will send it to the current object:
+
+```ruby
+field :post, PostType, null: true, cache_fragment: {cache_key: :title} do
+  argument :id, ID, required: true
+end
+
+# this is equal to
+def post(id:)
+  post = Post.find(id)
+  cache_fragment(object.title) { post }
+end
+```
+
+Finally, passing a proc to `cache_key:` allows you to use any arbitrary value:
+
+```ruby
+field :posts,
+  Types::Objects::PostType.connection_type,
+  cache_fragment: {cache_key: -> { object.posts.maximum(:created_at) }}
 ```
 
 The way cache key part is generated for the passed argument is the following:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ def post(id:)
 end
 ```
 
-You can pass the special `:value` symbol to the `cache_key:` argument to use the returned value to build a key:
+Also, you can pass `:value` to the `cache_key:` argument to use the returned value to build a key:
 
 ```ruby
 field :post, PostType, null: true, cache_fragment: {cache_key: :value} do
@@ -237,16 +237,12 @@ def post(id:)
 end
 ```
 
-Finally, passing a proc or any other symbol to `cache_key:` will evaluate it:
+If you need more control, you can set `cache_key:` to any custom code:
 
 ```ruby
 field :posts,
   Types::Objects::PostType.connection_type,
   cache_fragment: {cache_key: -> { object.posts.maximum(:created_at) }}
-
-field :post, PostType, null: true, cache_fragment: {cache_key: :my_method} do
-  argument :id, ID, required: true
-end
 ```
 
 The way cache key part is generated for the passed argument is the following:

--- a/README.md
+++ b/README.md
@@ -237,26 +237,16 @@ def post(id:)
 end
 ```
 
-Passing any other symbol to `cache_key:` will send it to the current object:
-
-```ruby
-field :post, PostType, null: true, cache_fragment: {cache_key: :title} do
-  argument :id, ID, required: true
-end
-
-# this is equal to
-def post(id:)
-  post = Post.find(id)
-  cache_fragment(object.title) { post }
-end
-```
-
-Finally, passing a proc to `cache_key:` allows you to use any arbitrary value:
+Finally, passing a proc or any other symbol to `cache_key:` will evaluate it:
 
 ```ruby
 field :posts,
   Types::Objects::PostType.connection_type,
   cache_fragment: {cache_key: -> { object.posts.maximum(:created_at) }}
+
+field :post, PostType, null: true, cache_fragment: {cache_key: :my_method} do
+  argument :id, ID, required: true
+end
 ```
 
 The way cache key part is generated for the passed argument is the following:

--- a/lib/graphql/fragment_cache/field_extension.rb
+++ b/lib/graphql/fragment_cache/field_extension.rb
@@ -63,10 +63,10 @@ module GraphQL
 
         object_for_key = if @context_key
           Array(@context_key).map { |key| object.context[key] }
-        elsif @cache_key == :object
-          object.object
         elsif @cache_key == :value
           resolved_value = yield(object, arguments)
+        elsif @cache_key.is_a?(Symbol)
+          object.send(@cache_key)
         elsif @cache_key.is_a?(Proc)
           object.instance_exec(&@cache_key)
         end

--- a/lib/graphql/fragment_cache/field_extension.rb
+++ b/lib/graphql/fragment_cache/field_extension.rb
@@ -51,22 +51,25 @@ module GraphQL
         if @if.is_a?(Proc) && !object.instance_exec(&@if)
           return yield(object, arguments)
         end
+
         if @if.is_a?(Symbol) && !object.send(@if)
           return yield(object, arguments)
         end
+
         if @unless.is_a?(Proc) && object.instance_exec(&@unless)
           return yield(object, arguments)
         end
+
         if @unless.is_a?(Symbol) && object.send(@unless)
           return yield(object, arguments)
         end
 
         object_for_key = if @context_key
           Array(@context_key).map { |key| object.context[key] }
+        elsif @cache_key == :object
+          object.object
         elsif @cache_key == :value
           resolved_value = yield(object, arguments)
-        elsif @cache_key.is_a?(Symbol)
-          object.send(@cache_key)
         elsif @cache_key.is_a?(Proc)
           object.instance_exec(&@cache_key)
         end

--- a/lib/graphql/fragment_cache/field_extension.rb
+++ b/lib/graphql/fragment_cache/field_extension.rb
@@ -55,6 +55,8 @@ module GraphQL
           object.object
         elsif @cache_key == :value
           resolved_value = yield(object, arguments)
+        elsif @cache_key.is_a?(Proc)
+          object.instance_exec(&@cache_key)
         end
         cache_fragment_options = @cache_options.merge(object: object_for_key)
 

--- a/lib/graphql/fragment_cache/field_extension.rb
+++ b/lib/graphql/fragment_cache/field_extension.rb
@@ -51,15 +51,12 @@ module GraphQL
         if @if.is_a?(Proc) && !object.instance_exec(&@if)
           return yield(object, arguments)
         end
-
         if @if.is_a?(Symbol) && !object.send(@if)
           return yield(object, arguments)
         end
-
         if @unless.is_a?(Proc) && object.instance_exec(&@unless)
           return yield(object, arguments)
         end
-
         if @unless.is_a?(Symbol) && object.send(@unless)
           return yield(object, arguments)
         end

--- a/spec/graphql/fragment_cache/field_extensions_spec.rb
+++ b/spec/graphql/fragment_cache/field_extensions_spec.rb
@@ -162,113 +162,115 @@ describe "cache_fragment: option" do
     end
   end
 
-  context "with cache_key: :object" do
-    let(:schema) do
-      post_type = Class.new(Types::Post) {
-        graphql_name "PostWithCachedAuthor"
-
-        field :cached_author, Types::User, null: true, cache_fragment: {cache_key: :object}
-
-        def cached_author
-          object.author
+  context "when :cache_key is provided" do
+    context "when :cache_key is the special :value Symbol" do
+      let(:schema) do
+        build_schema do
+          query(
+            Class.new(Types::Query) {
+              field :post, Types::Post, null: true, cache_fragment: {cache_key: :value} do
+                argument :id, GraphQL::Types::ID, required: true
+              end
+            }
+          )
         end
-      }
-
-      build_schema do
-        query(
-          Class.new(Types::Query) {
-            field :post, post_type, null: true do
-              argument :id, GraphQL::Types::ID, required: true
-            end
-          }
-        )
       end
-    end
 
-    let(:query) do
-      <<~GQL
-        query getPost($id: ID!){
-          post(id: $id) {
-            id
-            title
-            cachedAuthor {
+      let(:query) do
+        <<~GQL
+          query getPost($id: ID!){
+            post(id: $id) {
               id
-              name
+              title
             }
           }
-        }
-      GQL
-    end
+        GQL
+      end
 
-    let(:post) { Post.create(id: id, title: "option test", author: User.new(id: 22, name: "Jack")) }
+      let(:post) { Post.create(id: id, title: "option test") }
 
-    it "returns a new version of author when post.cache_key has changed" do
-      # re-warmup cache
-      execute_query
+      it "returns a new version of post when post.cache_key has changed" do
+        expect(execute_query.dig("data", "post")).to eq({
+          "id" => "1",
+          "title" => "new option test"
+        })
 
-      post.author.name = "John"
-      expect(execute_query.dig("data", "post", "cachedAuthor")).to eq({
-        "id" => "22",
-        "name" => "Jack"
-      })
+        post.title = "new option"
+        expect(execute_query.dig("data", "post")).to eq({
+          "id" => "1",
+          "title" => "new option"
+        })
+      end
 
-      post.title = "new option"
-      expect(execute_query.dig("data", "post", "cachedAuthor")).to eq({
-        "id" => "22",
-        "name" => "John"
-      })
-    end
-
-    it "calls resolver method" do
-      allow(::Post).to receive(:find).and_call_original
-      execute_query
-      expect(::Post).to have_received(:find).once
-    end
-  end
-
-  context "with cache_key: :value" do
-    let(:schema) do
-      build_schema do
-        query(
-          Class.new(Types::Query) {
-            field :post, Types::Post, null: true, cache_fragment: {cache_key: :value} do
-              argument :id, GraphQL::Types::ID, required: true
-            end
-          }
-        )
+      it "calls resolver method" do
+        allow(::Post).to receive(:find).and_call_original
+        execute_query
+        expect(::Post).to have_received(:find).once
       end
     end
 
-    let(:query) do
-      <<~GQL
-        query getPost($id: ID!){
-          post(id: $id) {
-            id
-            title
-          }
+    context "when :cache_key is a Symbol that is not :value" do
+      let(:schema) do
+        post_type = Class.new(Types::Post) {
+          graphql_name "PostWithCachedAuthor"
+
+          field :cached_author, Types::User, null: true, cache_fragment: {cache_key: :object}
+
+          def cached_author
+            object.author
+          end
         }
-      GQL
-    end
 
-    let(:post) { Post.create(id: id, title: "option test") }
+        build_schema do
+          query(
+            Class.new(Types::Query) {
+              field :post, post_type, null: true do
+                argument :id, GraphQL::Types::ID, required: true
+              end
+            }
+          )
+        end
+      end
 
-    it "returns a new version of post when post.cache_key has changed" do
-      expect(execute_query.dig("data", "post")).to eq({
-        "id" => "1",
-        "title" => "new option test"
-      })
+      let(:query) do
+        <<~GQL
+          query getPost($id: ID!){
+            post(id: $id) {
+              id
+              title
+              cachedAuthor {
+                id
+                name
+              }
+            }
+          }
+        GQL
+      end
 
-      post.title = "new option"
-      expect(execute_query.dig("data", "post")).to eq({
-        "id" => "1",
-        "title" => "new option"
-      })
-    end
+      let(:post) { Post.create(id: id, title: "option test", author: User.new(id: 22, name: "Jack")) }
 
-    it "calls resolver method" do
-      allow(::Post).to receive(:find).and_call_original
-      execute_query
-      expect(::Post).to have_received(:find).once
+      it "returns a new version of author when post.cache_key has changed" do
+        # re-warmup cache
+        execute_query
+
+        post.author.name = "John"
+        expect(execute_query.dig("data", "post", "cachedAuthor")).to eq({
+          "id" => "22",
+          "name" => "Jack"
+        })
+
+        post.title = "new option"
+        expect(execute_query.dig("data", "post", "cachedAuthor")).to eq({
+          "id" => "22",
+          "name" => "John"
+        })
+      end
+
+      it "calls resolver method" do
+        allow(::Post).to receive(:find).and_call_original
+        execute_query
+        expect(::Post).to have_received(:find).once
+      end
     end
   end
 


### PR DESCRIPTION
Making `cache_key` support procs is useful when you want complete control over the cache key.

For example:

```ruby
field :posts,
      Types::Objects::PostType.connection_type,
      cache_fragment: { cache_key: -> { object.posts.maximum(:created_at) } }

field :comments,
      Types::Objects::CommentType.connection_type,
      cache_fragment: { cache_key: -> { [current_tenant.id, object] } }

field :activities,
      Types::Objects::ActivityType.connection_type,
      cache_fragment: { cache_key: -> { object.id } }
```

It is already possible to have complete control over the cache key with the `cache_fragment(whatever_key_you_want_here) { post }` syntax.

This PR makes it possible to do the same with with the `cache_fragment: { cache_key: -> { whatever_key_you_want_here } }` syntax.

What do you think?

_PS: similarly to #85 we could also make `cache_key` support arbitrary symbols if the symbols are different from :object and :value by `send`ing the symbol to the object, although the fact that :object and :value are special values might be confusing_