### PR TITLE
Use a "graphql" cache namespace by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#87](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/87) Use a "graphql" cache namespace by default ([@jeromedalbert][])
+
 ## 1.14.0 (2022-10-26)
 
 - [PR#85](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/85) Support passing Symbols to `if:` and `unless:` ([@palkan][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- [PR#87](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/87) Use a "graphql" cache namespace by default ([@jeromedalbert][])
+- [PR#89](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/89) Use a "graphql" cache namespace by default ([@jeromedalbert][])
 
 ## 1.15.0 (2022-10-27)
 

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Cache keys consist of the following parts: namespace, implicit key, and explicit
 
 ### Cache namespace
 
-You can optionally define a namespace that will be prefixed to every cache key:
+The namespace is prefixed to every cached key. The default namespace is `graphql`, which is configurable:
 
 ```ruby
-GraphQL::FragmentCache.namespace = "my-prefix"
+GraphQL::FragmentCache.namespace = "graphql"
 ```
 
 ### Implicit cache key

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -83,6 +83,7 @@ module GraphQL
     end
 
     self.cache_store = MemoryStore.new
+    self.namespace = "graphql"
     self.default_options = {}
   end
 end

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -40,11 +40,11 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     allow(Digest::SHA1).to receive(:hexdigest) { |val| val }
   end
 
-  specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]" }
+  specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]" }
 
-  context "when a namespace is configured" do
+  context "when a different namespace is configured" do
     before { GraphQL::FragmentCache.namespace = "my-prefix" }
-    after { GraphQL::FragmentCache.namespace = nil }
+    after { GraphQL::FragmentCache.namespace = "graphql" }
 
     specify { is_expected.to eq "my-prefix/schema_key/cachedPost(id:#{id})[id.title]" }
   end
@@ -65,7 +65,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
   end
 
   context "when cached field has aliased selections" do
@@ -84,7 +84,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[postId:id.title.author[authorId:id.name]]" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[postId:id.title.author[authorId:id.name]]" }
   end
 
   context "when argument is input" do
@@ -107,7 +107,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:variables) { {inputWithId: {id: id, intArg: 42}} }
 
-    specify { is_expected.to eq "schema_key/cachedPostByInput(input_with_id:{id:#{id},int_arg:42})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPostByInput(input_with_id:{id:#{id},int_arg:42})[id.title.author[id.name]]" }
 
     context "when argument is complext input" do
       let(:query) do
@@ -129,7 +129,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
       let(:variables) { {complexPostInput: {stringArg: "woo", inputWithId: {id: id, intArg: 42}}} }
 
-      specify { is_expected.to eq "schema_key/cachedPostByComplexInput(complex_post_input:{input_with_id:{id:#{id},int_arg:42},string_arg:woo})[id.title.author[id.name]]" }
+      specify { is_expected.to eq "graphql/schema_key/cachedPostByComplexInput(complex_post_input:{input_with_id:{id:#{id},int_arg:42},string_arg:woo})[id.title.author[id.name]]" }
     end
   end
 
@@ -151,7 +151,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "schema_key/post(id:#{id})/cachedAuthor[id.name]" }
+    specify { is_expected.to eq "graphql/schema_key/post(id:#{id})/cachedAuthor[id.name]" }
   end
 
   context "when fragment is used" do
@@ -174,7 +174,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
 
     context "when nested fragment is used" do
       let(:path) { ["post", "cachedAuthor"] }
@@ -198,7 +198,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
         GQL
       end
 
-      specify { is_expected.to eq "schema_key/post(id:#{id})/cachedAuthor[id.name]" }
+      specify { is_expected.to eq "graphql/schema_key/post(id:#{id})/cachedAuthor[id.name]" }
     end
   end
 
@@ -218,13 +218,13 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author(cached:false,version:5)[id.name]]" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author(cached:false,version:5)[id.name]]" }
   end
 
   context "when object is passed and responds to #cache_key" do
     let(:object) { post }
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}" }
   end
 
   context "when object is passed and responds to #graphql_cache_key" do
@@ -234,14 +234,14 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:object) { post }
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/super-cache" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/super-cache" }
   end
 
   context "when object is passed deosn't respond to #cache_key neither #graphql_cache_key" do
     let(:object) { post.author }
 
     it "fallbacks to #to_s" do
-      is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{post.author}"
+      is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.author}"
     end
   end
 
@@ -250,14 +250,14 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     let(:object) { post.author }
 
     it "uses the option instead of the object's cache_key" do
-      is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{options[:object_cache_key]}"
+      is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{options[:object_cache_key]}"
     end
   end
 
   context "when array is passed as object" do
     let(:object) { [post, :custom, 99] }
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}/custom/99" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}/custom/99" }
   end
 
   context "when scalar field is cached inside the collection" do
@@ -274,7 +274,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["posts", 0, "cachedTitle"] }
 
-    specify { is_expected.to eq "schema_key/posts/0/cachedTitle[]" }
+    specify { is_expected.to eq "graphql/schema_key/posts/0/cachedTitle[]" }
   end
 
   context "when query has fragment" do
@@ -297,7 +297,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["post", "author"] }
 
-    specify { is_expected.to eq "schema_key/post(id:1)/cachedAuthor[name]" }
+    specify { is_expected.to eq "graphql/schema_key/post(id:1)/cachedAuthor[name]" }
   end
 
   context "when query has inline fragment" do
@@ -318,6 +318,6 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["post", "author"] }
 
-    specify { is_expected.to eq "schema_key/post(id:1)/cachedAuthor[name]" }
+    specify { is_expected.to eq "graphql/schema_key/post(id:1)/cachedAuthor[name]" }
   end
 end

--- a/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
@@ -39,7 +39,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
   it "uses Cache.expand_cache_key" do
     allow(ActiveSupport::Cache).to receive(:expand_cache_key).with(object) { "as:cache:key" }
 
-    is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/Post#42"
+    is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/Post#42"
   end
 
   context "when object is passed and responds to #graphql_cache_key" do
@@ -47,7 +47,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:graphql_cache_key) { "{graphql_cache_key}" }
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{graphql_cache_key}" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{graphql_cache_key}" }
   end
 
   context "when object is passed and responds to #cache_key_with_version" do
@@ -55,7 +55,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:cache_key_with_version) { "{cache_key_with_version}" }
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache_key_with_version}" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache_key_with_version}" }
   end
 
   context "when object is passed and responds to #cache_key" do
@@ -63,6 +63,6 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:cache_key) { "{cache-key}" }
     end
 
-    specify { is_expected.to eq "schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache-key}" }
+    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache-key}" }
   end
 end


### PR DESCRIPTION
I don't know if you want this, but I feel like prefixing keys with the "graphql" namespace should be the default.