### PR TITLE
Make cache keys human-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+- [PR#92](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/92) Make cache keys human-readable ([@jeromedalbert][])
+
 ## 1.16.0 (2022-11-06)
 
 - [PR#42](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/pull/42) Raise helpful errors when write or write_multi fails  ([@DmitryTsepelev][])

--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -139,7 +139,7 @@ module GraphQL
       def build
         key_parts = [
           GraphQL::FragmentCache.namespace,
-          path_cache_key_without_args,
+          simple_path_cache_key,
           implicit_cache_key,
           object_cache_key
         ]
@@ -176,7 +176,7 @@ module GraphQL
         current_root.selections.to_selections_key
       end
 
-      def path_cache_key_without_args
+      def simple_path_cache_key
         path_cache_key.split("(").first
       end
 

--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -137,11 +137,17 @@ module GraphQL
       end
 
       def build
-        [
+        key_parts = [
           GraphQL::FragmentCache.namespace,
+          path_cache_key_without_args,
           implicit_cache_key,
           object_cache_key
-        ].compact.join("/")
+        ]
+
+        key_parts
+          .compact
+          .map { |key_part| key_part.tr("/", "-") }
+          .join("/")
       end
 
       private
@@ -170,22 +176,28 @@ module GraphQL
         current_root.selections.to_selections_key
       end
 
+      def path_cache_key_without_args
+        path_cache_key.split("(").first
+      end
+
       def path_cache_key
-        @options.fetch(:path_cache_key) do
-          lookahead = query.lookahead
+        @path_cache_key ||= begin
+          @options.fetch(:path_cache_key) do
+            lookahead = query.lookahead
 
-          path.map { |field_name|
-            # Handle cached fields inside collections:
-            next field_name if field_name.is_a?(Integer)
+            path.map { |field_name|
+              # Handle cached fields inside collections:
+              next field_name if field_name.is_a?(Integer)
 
-            lookahead = lookahead.selection_with_alias(field_name)
-            raise "Failed to look ahead the field: #{field_name}" if lookahead.is_a?(::GraphQL::Execution::Lookahead::NullLookahead)
+              lookahead = lookahead.selection_with_alias(field_name)
+              raise "Failed to look ahead the field: #{field_name}" if lookahead.is_a?(::GraphQL::Execution::Lookahead::NullLookahead)
 
-            next lookahead.field.name if lookahead.arguments.empty?
+              next lookahead.field.name if lookahead.arguments.empty?
 
-            args = lookahead.arguments.map { "#{_1}:#{traverse_argument(_2)}" }.sort.join(",")
-            "#{lookahead.field.name}(#{args})"
-          }.join("/")
+              args = lookahead.arguments.map { "#{_1}:#{traverse_argument(_2)}" }.sort.join(",")
+              "#{lookahead.field.name}(#{args})"
+            }.join("/")
+          end
         end
       end
 

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -40,13 +40,13 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     allow(Digest::SHA1).to receive(:hexdigest) { |val| val }
   end
 
-  specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]" }
+  specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]" }
 
   context "when a different namespace is configured" do
     before { GraphQL::FragmentCache.namespace = "my-prefix" }
     after { GraphQL::FragmentCache.namespace = "graphql" }
 
-    specify { is_expected.to eq "my-prefix/schema_key/cachedPost(id:#{id})[id.title]" }
+    specify { is_expected.to eq "my-prefix/cachedPost/schema_key-cachedPost(id:#{id})[id.title]" }
   end
 
   context "when cached field has nested selections" do
@@ -65,7 +65,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]" }
   end
 
   context "when cached field has aliased selections" do
@@ -84,7 +84,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[postId:id.title.author[authorId:id.name]]" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[postId:id.title.author[authorId:id.name]]" }
   end
 
   context "when argument is input" do
@@ -107,7 +107,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:variables) { {inputWithId: {id: id, intArg: 42}} }
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPostByInput(input_with_id:{id:#{id},int_arg:42})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/cachedPostByInput/schema_key-cachedPostByInput(input_with_id:{id:#{id},int_arg:42})[id.title.author[id.name]]" }
 
     context "when argument is complext input" do
       let(:query) do
@@ -129,7 +129,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
       let(:variables) { {complexPostInput: {stringArg: "woo", inputWithId: {id: id, intArg: 42}}} }
 
-      specify { is_expected.to eq "graphql/schema_key/cachedPostByComplexInput(complex_post_input:{input_with_id:{id:#{id},int_arg:42},string_arg:woo})[id.title.author[id.name]]" }
+      specify { is_expected.to eq "graphql/cachedPostByComplexInput/schema_key-cachedPostByComplexInput(complex_post_input:{input_with_id:{id:#{id},int_arg:42},string_arg:woo})[id.title.author[id.name]]" }
     end
   end
 
@@ -151,7 +151,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "graphql/schema_key/post(id:#{id})/cachedAuthor[id.name]" }
+    specify { is_expected.to eq "graphql/post/schema_key-post(id:#{id})-cachedAuthor[id.name]" }
   end
 
   context "when fragment is used" do
@@ -174,7 +174,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]" }
 
     context "when nested fragment is used" do
       let(:path) { ["post", "cachedAuthor"] }
@@ -198,7 +198,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
         GQL
       end
 
-      specify { is_expected.to eq "graphql/schema_key/post(id:#{id})/cachedAuthor[id.name]" }
+      specify { is_expected.to eq "graphql/post/schema_key-post(id:#{id})-cachedAuthor[id.name]" }
     end
   end
 
@@ -218,13 +218,13 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       GQL
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author(cached:false,version:5)[id.name]]" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author(cached:false,version:5)[id.name]]" }
   end
 
   context "when object is passed and responds to #cache_key" do
     let(:object) { post }
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]/#{post.cache_key}" }
   end
 
   context "when object is passed and responds to #graphql_cache_key" do
@@ -234,14 +234,14 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:object) { post }
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/super-cache" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]/super-cache" }
   end
 
   context "when object is passed deosn't respond to #cache_key neither #graphql_cache_key" do
     let(:object) { post.author }
 
     it "fallbacks to #to_s" do
-      is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.author}"
+      is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]/#{post.author}"
     end
   end
 
@@ -250,14 +250,14 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
     let(:object) { post.author }
 
     it "uses the option instead of the object's cache_key" do
-      is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{options[:object_cache_key]}"
+      is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]/test_cache_key-1-230834092834098"
     end
   end
 
   context "when array is passed as object" do
     let(:object) { [post, :custom, 99] }
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title]/#{post.cache_key}/custom/99" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title]/#{post.cache_key}-custom-99" }
   end
 
   context "when scalar field is cached inside the collection" do
@@ -274,7 +274,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["posts", 0, "cachedTitle"] }
 
-    specify { is_expected.to eq "graphql/schema_key/posts/0/cachedTitle[]" }
+    specify { is_expected.to eq "graphql/posts-0-cachedTitle/schema_key-posts-0-cachedTitle[]" }
   end
 
   context "when query has fragment" do
@@ -297,7 +297,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["post", "author"] }
 
-    specify { is_expected.to eq "graphql/schema_key/post(id:1)/cachedAuthor[name]" }
+    specify { is_expected.to eq "graphql/post/schema_key-post(id:1)-cachedAuthor[name]" }
   end
 
   context "when query has inline fragment" do
@@ -318,6 +318,6 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     let(:path) { ["post", "author"] }
 
-    specify { is_expected.to eq "graphql/schema_key/post(id:1)/cachedAuthor[name]" }
+    specify { is_expected.to eq "graphql/post/schema_key-post(id:1)-cachedAuthor[name]" }
   end
 end

--- a/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/rails/cache_key_builder_spec.rb
@@ -39,7 +39,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
   it "uses Cache.expand_cache_key" do
     allow(ActiveSupport::Cache).to receive(:expand_cache_key).with(object) { "as:cache:key" }
 
-    is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/Post#42"
+    is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]/Post#42"
   end
 
   context "when object is passed and responds to #graphql_cache_key" do
@@ -47,7 +47,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:graphql_cache_key) { "{graphql_cache_key}" }
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{graphql_cache_key}" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]/{graphql_cache_key}" }
   end
 
   context "when object is passed and responds to #cache_key_with_version" do
@@ -55,7 +55,7 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:cache_key_with_version) { "{cache_key_with_version}" }
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache_key_with_version}" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]/{cache_key_with_version}" }
   end
 
   context "when object is passed and responds to #cache_key" do
@@ -63,6 +63,6 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
       object.singleton_class.define_method(:cache_key) { "{cache-key}" }
     end
 
-    specify { is_expected.to eq "graphql/schema_key/cachedPost(id:#{id})[id.title.author[id.name]]/{cache-key}" }
+    specify { is_expected.to eq "graphql/cachedPost/schema_key-cachedPost(id:#{id})[id.title.author[id.name]]/{cache-key}" }
   end
 end


### PR DESCRIPTION
Show the non-fingerprinted simple path in the cache key to make it more readable. The simple path is just the path but without parameters.

The cache key is now made up of 4 parts: namespace, simple path cache key, implicit cache key, and object cache key.

Each part is delimited by `/`, and within each part the delimiter is `-`. This way it is easy to see at a glance where the parts are. Here are some examples keys:

```
[41] pry(main)> $redis.keys('graphql*').sort
[
    [ 0] "graphql/post/766b6ccc10ab9495379351ee8beafea5c6007503/1595-mycorp",
    [ 1] "graphql/currentTenant-activities/8fb06e96554aadb59acc95055d94ac32e35ad383/1595-mycorp",
    [ 2] "graphql/currentTenant-posts/f328972b1d41071057c1e9b2ba2942376ead0def/posts-query-5f6b140cd0b110df8830cb806289afae-6-20220927164337385299-mycorp",
    [ 3] "graphql/currentTenant-orgs/8cd8ca77d3d80ce63a3c71f3458e13f871976742/orgs-query-a1cd705421842de6905cfb2f6c372fc8-1-20220908170650370442-mycorp",
    [ 4] "graphql/currentTenant-orgs/9d43405f9a04e5a7007c7a5b23e9a83025195513/orgs-query-a1cd705421842de6905cfb2f6c372fc8-1-20220908170650370442-mycorp",
    [ 5] "graphql/currentUser-companies-0-plans/636959b06ed3087a042294887cf024825324b17d/companies-28712-20221017002729396154-mycorp",
    [ 6] "graphql/currentUser-companies/3ce35c987a1634135bfdde439535f8d0d80c70ab/users-234196-20221017141421202813-mycorp",
    [ 7] "graphql/tool/136783447b0def9ee3eeffdee6e7d0724b25729d",
    [ 8] "graphql/tool/18ab5818aea282fc778f11f263862d7420491eab/tools-989-20221018005011056666-mycorp",
    [ 9] "graphql/tool/476a0e82181713884b6fc38efd8668cb55b35e16/companies-1281-20221018005011252828-mycorp",
    [10] "graphql/tool/59965cf1a9b31ce7dae6722c5a786a66658c865e/tools-989-20221018005011056666-mycorp"
]
```

This PR fixes #88.