### PR TITLE
Fix an error when path_cache_key is nil

### DIFF
--- a/lib/graphql/fragment_cache/cache_key_builder.rb
+++ b/lib/graphql/fragment_cache/cache_key_builder.rb
@@ -177,6 +177,8 @@ module GraphQL
       end
 
       def simple_path_cache_key
+        return if path_cache_key.nil?
+
         path_cache_key.split("(").first
       end
 

--- a/spec/graphql/fragment_cache/cache_key_builder_spec.rb
+++ b/spec/graphql/fragment_cache/cache_key_builder_spec.rb
@@ -320,4 +320,10 @@ describe GraphQL::FragmentCache::CacheKeyBuilder do
 
     specify { is_expected.to eq "graphql/post/schema_key-post(id:1)-cachedAuthor[name]" }
   end
+
+  context "when path_cache_key is nil" do
+    let(:options) { { path_cache_key: nil } }
+
+    specify { is_expected.to eq "graphql/schema_key-[id.title]" }
+  end
 end


### PR DESCRIPTION
The change in #92 now causes an error if `path_cache_key` is nil.
This PR fixes it.

```
undefined method `split' for nil:NilClass

        path_cache_key.split("(").first
                      ^^^^^^
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/cache_key_builder.rb:180:in `simple_path_cache_key'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/cache_key_builder.rb:142:in `build'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/cache_key_builder.rb:125:in `call'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/fragment.rb:56:in `cache_key'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/fragment.rb:20:in `block in read_multi'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/fragment.rb:20:in `map'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/fragment.rb:20:in `read_multi'
/usr/local/bundle/gems/graphql-fragment_cache-1.18.1/lib/graphql/fragment_cache/schema/lazy_cache_resolver.rb:23:in `resolve'
...
```



There is a workaround to set `path_cache_key` to an empty string, but I'd like to set nil to unify the writing style with `schema_cache_key`, etc.

```ruby
cache_fragment(post, schema_cache_key: nil, path_cache_key: nil)
```