### PR TITLE
Implicit config for test env

### DIFF
--- a/lib/graphql/fragment_cache/railtie.rb
+++ b/lib/graphql/fragment_cache/railtie.rb
@@ -23,10 +23,6 @@ module GraphQL
       end
 
       config.graphql_fragment_cache = Config
-
-      if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"
-        config.graphql_fragment_cache.store = :null_store
-      end
     end
   end
 end


### PR DESCRIPTION
Here is the problem with Rails 7.1 and this gem configuration. With Rails 7.1, in test environment, we always will see warning about cache format, because this gem creates cache store before rails app was initialized.

```bash
rails -v # -> Rails 7.1.2
rails new testapp && cd testapp && bundle add graphql-fragment_cache
RAILS_ENV=test bin/rails c

DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from block (2 levels) in require at /Users/lazureykis/.asdf/installs/ruby/3.2.2/lib/ruby/site_ruby/3.2.0/bundler/runtime.rb:60)
Loading test environment (Rails 7.1.2)
irb(main):001>

```