### PR TITLE
Use trace_with instead of deprecated instrument method 

### DIFF
--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -33,7 +33,7 @@ module GraphQL
 
         schema_defn.tracer(Schema::Tracer)
         schema_defn.trace_with(GraphQL::Tracing::LegacyHooksTrace)
-        schema_defn.own_instrumenters[:query] << Schema::Instrumentation
+        schema_defn.instance_exec { own_instrumenters[:query] << Schema::Instrumentation }
 
         schema_defn.extend(Schema::Patch)
         schema_defn.lazy_resolve(Schema::LazyCacheResolver, :resolve)

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -32,7 +32,9 @@ module GraphQL
         verify_interpreter_and_analysis!(schema_defn)
 
         schema_defn.tracer(Schema::Tracer)
-        schema_defn.instrument(:query, Schema::Instrumentation)
+        schema_defn.trace_with(GraphQL::Tracing::LegacyHooksTrace)
+        schema_defn.own_instrumenters[:query] << Schema::Instrumentation
+
         schema_defn.extend(Schema::Patch)
         schema_defn.lazy_resolve(Schema::LazyCacheResolver, :resolve)
 

--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -32,8 +32,13 @@ module GraphQL
         verify_interpreter_and_analysis!(schema_defn)
 
         schema_defn.tracer(Schema::Tracer)
-        schema_defn.trace_with(GraphQL::Tracing::LegacyHooksTrace)
-        schema_defn.instance_exec { own_instrumenters[:query] << Schema::Instrumentation }
+
+        if graphql_ruby_after_2_2_5?
+          schema_defn.trace_with(GraphQL::Tracing::LegacyHooksTrace)
+          schema_defn.instance_exec { own_instrumenters[:query] << Schema::Instrumentation }
+        else
+          schema_defn.instrument(:query, Schema::Instrumentation)
+        end
 
         schema_defn.extend(Schema::Patch)
         schema_defn.lazy_resolve(Schema::LazyCacheResolver, :resolve)
@@ -69,6 +74,10 @@ module GraphQL
 
       def graphql_ruby_before_2_1_4?
         check_graphql_version "< 2.1.4"
+      end
+
+      def graphql_ruby_after_2_2_5?
+        check_graphql_version "> 2.2.5"
       end
 
       private


### PR DESCRIPTION
With the latest version of the `graphql` gem, you get this warning:
```
Schema.instrument is deprecated, use `trace_with` instead: https://graphql-ruby.org/queries/tracing.html"
```

This PR fixes #107 