### PR TITLE
replace deprecated .tracer method with .trace_with

### DIFF
--- a/lib/graphql/fragment_cache.rb
+++ b/lib/graphql/fragment_cache.rb
@@ -33,7 +33,7 @@ module GraphQL
       def use(schema_defn, options = {})
         verify_interpreter_and_analysis!(schema_defn)
 
-        schema_defn.tracer(Schema::Tracer)
+        schema_defn.trace_with(Schema::Tracer)
 
         if GraphRubyVersion.after_2_2_5?
           schema_defn.trace_with(GraphQL::Tracing::LegacyHooksTrace)


### PR DESCRIPTION
The `.tracer` method has been deprecated in graphql-ruby 2.3.0. This replaces it with the new `.trace_with` method

Mentioned in [this issue](https://github.com/DmitryTsepelev/graphql-ruby-fragment_cache/issues/110)