### PR TITLE
Fix deprecation warning for cache_format_version in Rails 7.1

### DIFF
--- a/lib/graphql/fragment_cache/railtie.rb
+++ b/lib/graphql/fragment_cache/railtie.rb
@@ -10,6 +10,9 @@ module GraphQL
       module Config
         class << self
           def store=(store)
+            cache_format_version = Rails.application&.config&.active_support&.cache_format_version
+            ActiveSupport::Cache.format_version = cache_format_version if cache_format_version
+
             # Handle both:
             #   store = :memory
             #   store = :mem_cache, ENV['MEMCACHE']

--- a/lib/graphql/fragment_cache/railtie.rb
+++ b/lib/graphql/fragment_cache/railtie.rb
@@ -10,8 +10,10 @@ module GraphQL
       module Config
         class << self
           def store=(store)
-            cache_format_version = Rails.application&.config&.active_support&.cache_format_version
-            ActiveSupport::Cache.format_version = cache_format_version if cache_format_version
+            if Rails.version.to_f >= 7.0 && Rails.application
+              cache_format_version = Rails.application.config.active_support.cache_format_version
+              ActiveSupport::Cache.format_version = cache_format_version if cache_format_version
+            end
 
             # Handle both:
             #   store = :memory

--- a/spec/graphql/fragment_cache/rails/railtie_spec.rb
+++ b/spec/graphql/fragment_cache/rails/railtie_spec.rb
@@ -16,5 +16,12 @@ describe GraphQL::FragmentCache::Railtie do
       expect(GraphQL::FragmentCache.cache_store).to be_a(ActiveSupport::Cache::MemoryStore)
       expect(GraphQL::FragmentCache.cache_store.options[:max_size]).to eq 10.megabytes
     end
+
+    it "updates ActiveSupport::Cache.format_version" do
+      Rails.application.config.active_support.cache_format_version = 7.0
+      Rails.application.config.graphql_fragment_cache.store = :memory_store
+
+      expect(ActiveSupport::Cache.format_version).to eq 7.0
+    end
   end
 end

--- a/spec/graphql/fragment_cache/rails/railtie_spec.rb
+++ b/spec/graphql/fragment_cache/rails/railtie_spec.rb
@@ -17,7 +17,8 @@ describe GraphQL::FragmentCache::Railtie do
       expect(GraphQL::FragmentCache.cache_store.options[:max_size]).to eq 10.megabytes
     end
 
-    it "updates ActiveSupport::Cache.format_version" do
+    it "updates ActiveSupport::Cache.format_version when rails version is 7.0 or higher" do
+      allow(Rails).to receive(:version).and_return("7.0")
       Rails.application.config.active_support.cache_format_version = 7.0
       Rails.application.config.graphql_fragment_cache.store = :memory_store
 


### PR DESCRIPTION
With Rails 7.1, we will see warning about cache format like below.
To solve it, set the cache format version according to Rails configuration.

```bash
$ rails c
DEPRECATION WARNING: Support for `config.active_support.cache_format_version = 6.1` has been deprecated and will be removed in Rails 7.2.

Check the Rails upgrade guide at https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activesupport-cache-serialization-format
for more information on how to upgrade.
 (called from <class:Application> at /Users/.../config/application.rb:63)
```