### PR TITLE
Fix warning on ActiveSupport::Cache.format_version

### DIFF
--- a/lib/graphql/fragment_cache/railtie.rb
+++ b/lib/graphql/fragment_cache/railtie.rb
@@ -10,11 +10,6 @@ module GraphQL
       module Config
         class << self
           def store=(store)
-            if Rails.version.to_f >= 7.0 && Rails.application
-              cache_format_version = 7.0
-              ActiveSupport::Cache.format_version = cache_format_version if cache_format_version
-            end
-
             # Handle both:
             #   store = :memory
             #   store = :mem_cache, ENV['MEMCACHE']
@@ -30,7 +25,13 @@ module GraphQL
       config.graphql_fragment_cache = Config
 
       if ENV["RACK_ENV"] == "test" || ENV["RAILS_ENV"] == "test"
-        config.graphql_fragment_cache.store = :null_store
+        initializer "graphql-fragment_cache" do
+          config.graphql_fragment_cache.store = if Rails.version.to_f >= 7.0
+            [:null_store, serializer: :marshal_7_0]
+          else
+            :null_store
+          end
+        end
       end
     end
   end

--- a/spec/graphql/fragment_cache/cacher_spec.rb
+++ b/spec/graphql/fragment_cache/cacher_spec.rb
@@ -44,11 +44,9 @@ describe GraphQL::FragmentCache::Cacher do
 
     let(:store) { write_multi_store_class.new }
 
-    around do |ex|
-      old_store = GraphQL::FragmentCache.cache_store
+    before do
+      allow(store).to receive(:write_multi).and_call_original
       GraphQL::FragmentCache.cache_store = store
-      ex.run
-      GraphQL::FragmentCache.cache_store = old_store
     end
 
     it "uses #write_multi" do
@@ -134,11 +132,8 @@ describe GraphQL::FragmentCache::Cacher do
 
     let(:store) { write_with_error_store_class.new }
 
-    around do |ex|
-      old_store = GraphQL::FragmentCache.cache_store
+    before do
       GraphQL::FragmentCache.cache_store = store
-      ex.run
-      GraphQL::FragmentCache.cache_store = old_store
     end
 
     it "raises error" do

--- a/spec/graphql/fragment_cache/rails/railtie_spec.rb
+++ b/spec/graphql/fragment_cache/rails/railtie_spec.rb
@@ -16,13 +16,5 @@ describe GraphQL::FragmentCache::Railtie do
       expect(GraphQL::FragmentCache.cache_store).to be_a(ActiveSupport::Cache::MemoryStore)
       expect(GraphQL::FragmentCache.cache_store.options[:max_size]).to eq 10.megabytes
     end
-
-    it "updates ActiveSupport::Cache.format_version when rails version is 7.0 or higher" do
-      allow(Rails).to receive(:version).and_return("7.0")
-      Rails.application.config.active_support.cache_format_version = 7.0
-      Rails.application.config.graphql_fragment_cache.store = :memory_store
-
-      expect(ActiveSupport::Cache.format_version).to eq 7.0
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,4 @@ require "spec_helper"
 require "combustion"
 require "graphql/fragment_cache/railtie"
 
-GraphQL::FragmentCache.cache_store = GraphQL::FragmentCache::MemoryStore.new
-
 Combustion.initialize! :active_record

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,8 +32,11 @@ RSpec.configure do |config|
   config.include SchemaHelper
   config.include_context "graphql"
 
-  config.after do
-    GraphQL::FragmentCache.cache_store.clear if GraphQL::FragmentCache.cache_store.respond_to?(:clear)
+  config.before do
+    GraphQL::FragmentCache.cache_store = GraphQL::FragmentCache::MemoryStore.new
+  end
+
+  config.before do
     Post.delete_all
     Timecop.return
   end


### PR DESCRIPTION
Fixes #114 

`Rail.application` was always evaluating to `nil` before as the code wasn't running in an initializer.

I changed the approach slightly to be less intrusive: now we simply initialize the cache store with a non-deprecated serializer, instead of modifying the `ActiveSupport.cache_format_version` configuration.

---

NOTE: after my change, if the user is on Rails >= 7 and didn't configure `ActiveSupport::Cache.format_version`, if they manually change the store (e.g.: `Rails.application.config.graphql_fragment_cache = :memory_store`), that will raise a ActiveSupport warning.
I believe this behaviour is appropriate - the user should set an appropriate cache_format_version before setting the cache store.