### PR TITLE
Update README.md - correct path_cache_key code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ end
 field :cached_avatar_url, String, null: false
 
 def cached_avatar_url
-  cache_fragment(query_cache_key: "post_avatar_url(#{object.id})") { object.avatar_url }
+  cache_fragment(path_cache_key: "post_avatar_url(#{object.id})") { object.avatar_url }
 end
 ```
 


### PR DESCRIPTION
Providing a `path_cache_key` will resolve the `Lookahead` problem, per the documentation. However, the code example is showing a `query_cache_key`, not the `path_cache_key`. 

This PR fixes that.